### PR TITLE
Refactor tile_yolo.py into a class

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This script can cut images and corresponding labels from YOLO dataset into tiles
 
 ## Usage 
 
-`python3 tyle_yolo.py -source ./yolosample/ts/ -target ./yolosliced/ts/ -ext .JPG -size 512`
+`python3 tile_yolo.py -source ./yolosample/ts/ -target ./yolosliced/ts/ -ext .JPG -size 512`
 
 ## Arguments
 
@@ -17,4 +17,13 @@ This script can cut images and corresponding labels from YOLO dataset into tiles
 - **-size**          Size of a tile. Default: 416
 - **-ratio**         Train/test split ratio. Dafault: 0.8
 
+## Class-based Usage
 
+To use the script as a class, you can create an instance of the `YoloTiler` class and call its `run` method:
+
+```python
+from tile_yolo import YoloTiler
+
+yolo_tiler = YoloTiler(source="./yolosample/ts/", target="./yolosliced/ts/", ext=".JPG", falsefolder=None, size=512, ratio=0.8)
+yolo_tiler.run()
+```

--- a/tile_yolo.py
+++ b/tile_yolo.py
@@ -7,126 +7,149 @@ import argparse
 import os
 import random
 from shutil import copyfile
- 
 
-def tiler(imnames, newpath, falsepath, slice_size, ext):
-    for imname in imnames:
-        im = Image.open(imname)
-        imr = np.array(im, dtype=np.uint8)
-        height = imr.shape[0]
-        width = imr.shape[1]
-        labname = imname.replace(ext, '.txt')
-        labels = pd.read_csv(labname, sep=' ', names=['class', 'x1', 'y1', 'w', 'h'])
-        
-        # we need to rescale coordinates from 0-1 to real image height and width
-        labels[['x1', 'w']] = labels[['x1', 'w']] * width
-        labels[['y1', 'h']] = labels[['y1', 'h']] * height
-        
-        boxes = []
-        
-        # convert bounding boxes to shapely polygons. We need to invert Y and find polygon vertices from center points
-        for row in labels.iterrows():
-            x1 = row[1]['x1'] - row[1]['w']/2
-            y1 = (height - row[1]['y1']) - row[1]['h']/2
-            x2 = row[1]['x1'] + row[1]['w']/2
-            y2 = (height - row[1]['y1']) + row[1]['h']/2
+class YoloTiler:
+    def __init__(self, source, target, ext, falsefolder, size, ratio):
+        self.source = source
+        self.target = target
+        self.ext = ext
+        self.falsefolder = falsefolder
+        self.size = size
+        self.ratio = ratio
 
-            boxes.append((int(row[1]['class']), Polygon([(x1, y1), (x2, y1), (x2, y2), (x1, y2)])))
-        
-        counter = 0
-        print('Image:', imname)
-        # create tiles and find intersection with bounding boxes for each tile
-        for i in range((height // slice_size)):
-            for j in range((width // slice_size)):
-                x1 = j*slice_size
-                y1 = height - (i*slice_size)
-                x2 = ((j+1)*slice_size) - 1
-                y2 = (height - (i+1)*slice_size) + 1
+    def tiler(self, imnames, newpath, falsepath, slice_size, ext):
+        for imname in imnames:
+            im = Image.open(imname)
+            imr = np.array(im, dtype=np.uint8)
+            height = imr.shape[0]
+            width = imr.shape[1]
+            labname = imname.replace(ext, '.txt')
+            labels = pd.read_csv(labname, sep=' ', names=['class', 'x1', 'y1', 'w', 'h'])
 
-                pol = Polygon([(x1, y1), (x2, y1), (x2, y2), (x1, y2)])
-                imsaved = False
-                slice_labels = []
+            labels[['x1', 'w']] = labels[['x1', 'w']] * width
+            labels[['y1', 'h']] = labels[['y1', 'h']] * height
 
-                for box in boxes:
-                    if pol.intersects(box[1]):
-                        inter = pol.intersection(box[1])        
-                        
-                        if not imsaved:
-                            sliced = imr[i*slice_size:(i+1)*slice_size, j*slice_size:(j+1)*slice_size]
-                            sliced_im = Image.fromarray(sliced)
-                            filename = imname.split('/')[-1]
-                            slice_path = newpath + "/" + filename.replace(ext, f'_{i}_{j}{ext}')                            
-                            slice_labels_path = newpath + "/" + filename.replace(ext, f'_{i}_{j}.txt')                            
-                            print(slice_path)
-                            sliced_im.save(slice_path)
-                            imsaved = True                    
-                        
-                        # get smallest rectangular polygon (with sides parallel to the coordinate axes) that contains the intersection
-                        new_box = inter.envelope 
-                        
-                        # get central point for the new bounding box 
-                        centre = new_box.centroid
-                        
-                        # get coordinates of polygon vertices
-                        x, y = new_box.exterior.coords.xy
-                        
-                        # get bounding box width and height normalized to slice size
-                        new_width = (max(x) - min(x)) / slice_size
-                        new_height = (max(y) - min(y)) / slice_size
-                        
-                        # we have to normalize central x and invert y for yolo format
-                        new_x = (centre.coords.xy[0][0] - x1) / slice_size
-                        new_y = (y1 - centre.coords.xy[1][0]) / slice_size
-                        
-                        counter += 1
+            boxes = []
 
-                        slice_labels.append([box[0], new_x, new_y, new_width, new_height])
-                
-                if len(slice_labels) > 0:
-                    slice_df = pd.DataFrame(slice_labels, columns=['class', 'x1', 'y1', 'w', 'h'])
-                    print(slice_df)
-                    slice_df.to_csv(slice_labels_path, sep=' ', index=False, header=False, float_format='%.6f')
-                
-                if not imsaved and falsepath:
-                    sliced = imr[i*slice_size:(i+1)*slice_size, j*slice_size:(j+1)*slice_size]
-                    sliced_im = Image.fromarray(sliced)
-                    filename = imname.split('/')[-1]
-                    slice_path = falsepath + "/" + filename.replace(ext, f'_{i}_{j}{ext}')                
+            for row in labels.iterrows():
+                x1 = row[1]['x1'] - row[1]['w']/2
+                y1 = (height - row[1]['y1']) - row[1]['h']/2
+                x2 = row[1]['x1'] + row[1]['w']/2
+                y2 = (height - row[1]['y1']) + row[1]['h']/2
 
-                    sliced_im.save(slice_path)
-                    print('Slice without boxes saved')
-                    imsaved = True
+                boxes.append((int(row[1]['class']), Polygon([(x1, y1), (x2, y1), (x2, y2), (x1, y2)])))
 
-def splitter(target, target_upfolder, ext, ratio):
-    imnames = glob.glob(f'{target}/*{ext}')
-    names = [name.split('/')[-1] for name in imnames]
+            counter = 0
+            print('Image:', imname)
+            for i in range((height // slice_size)):
+                for j in range((width // slice_size)):
+                    x1 = j*slice_size
+                    y1 = height - (i*slice_size)
+                    x2 = ((j+1)*slice_size) - 1
+                    y2 = (height - (i+1)*slice_size) + 1
 
-    # split dataset for train and test
+                    pol = Polygon([(x1, y1), (x2, y1), (x2, y2), (x1, y2)])
+                    imsaved = False
+                    slice_labels = []
 
-    train = []
-    test = []
-    for name in names:
-        if random.random() > ratio:
-            test.append(os.path.join(target, name))
+                    for box in boxes:
+                        if pol.intersects(box[1]):
+                            inter = pol.intersection(box[1])
+
+                            if not imsaved:
+                                sliced = imr[i*slice_size:(i+1)*slice_size, j*slice_size:(j+1)*slice_size]
+                                sliced_im = Image.fromarray(sliced)
+                                filename = imname.split('/')[-1]
+                                slice_path = newpath + "/" + filename.replace(ext, f'_{i}_{j}{ext}')
+                                slice_labels_path = newpath + "/" + filename.replace(ext, f'_{i}_{j}.txt')
+                                print(slice_path)
+                                sliced_im.save(slice_path)
+                                imsaved = True
+
+                            new_box = inter.envelope
+
+                            centre = new_box.centroid
+
+                            x, y = new_box.exterior.coords.xy
+
+                            new_width = (max(x) - min(x)) / slice_size
+                            new_height = (max(y) - min(y)) / slice_size
+
+                            new_x = (centre.coords.xy[0][0] - x1) / slice_size
+                            new_y = (y1 - centre.coords.xy[1][0]) / slice_size
+
+                            counter += 1
+
+                            slice_labels.append([box[0], new_x, new_y, new_width, new_height])
+
+                    if len(slice_labels) > 0:
+                        slice_df = pd.DataFrame(slice_labels, columns=['class', 'x1', 'y1', 'w', 'h'])
+                        print(slice_df)
+                        slice_df.to_csv(slice_labels_path, sep=' ', index=False, header=False, float_format='%.6f')
+
+                    if not imsaved and falsepath:
+                        sliced = imr[i*slice_size:(i+1)*slice_size, j*slice_size:(j+1)*slice_size]
+                        sliced_im = Image.fromarray(sliced)
+                        filename = imname.split('/')[-1]
+                        slice_path = falsepath + "/" + filename.replace(ext, f'_{i}_{j}{ext}')
+
+                        sliced_im.save(slice_path)
+                        print('Slice without boxes saved')
+                        imsaved = True
+
+    def splitter(self, target, target_upfolder, ext, ratio):
+        imnames = glob.glob(f'{target}/*{ext}')
+        names = [name.split('/')[-1] for name in imnames]
+
+        train = []
+        test = []
+        for name in names:
+            if random.random() > ratio:
+                test.append(os.path.join(target, name))
+            else:
+                train.append(os.path.join(target, name))
+        print('train:', len(train))
+        print('test:', len(test))
+
+        with open(f'{target_upfolder}/train.txt', 'w') as f:
+            for item in train:
+                f.write("%s\n" % item)
+
+        with open(f'{target_upfolder}/test.txt', 'w') as f:
+            for item in test:
+                f.write("%s\n" % item)
+
+    def run(self):
+        imnames = glob.glob(f'{self.source}/*{self.ext}')
+        labnames = glob.glob(f'{self.source}/*.txt')
+
+        if len(imnames) == 0:
+            raise Exception("Source folder should contain some images")
+        elif len(imnames) != len(labnames):
+            raise Exception("Dataset should contain equal number of images and txt files with labels")
+
+        if not os.path.exists(self.target):
+            os.makedirs(self.target)
+        elif len(os.listdir(self.target)) > 0:
+            raise Exception("Target folder should be empty")
+
+        upfolder = os.path.join(self.source, '..' )
+        target_upfolder = os.path.join(self.target, '..' )
+        if not os.path.exists(os.path.join(upfolder, 'classes.names')):
+            print('classes.names not found. It should be located one level higher than images')
         else:
-            train.append(os.path.join(target, name))
-    print('train:', len(train))
-    print('test:', len(test))
+            copyfile(os.path.join(upfolder, 'classes.names'), os.path.join(target_upfolder, 'classes.names'))
 
-    # we will put test.txt, train.txt in a folder one level higher than images
+        if self.falsefolder:
+            if not os.path.exists(self.falsefolder):
+                os.makedirs(self.falsefolder)
+            elif len(os.listdir(self.falsefolder)) > 0:
+                raise Exception("Folder for tiles without boxes should be empty")
 
-    # save train part
-    with open(f'{target_upfolder}/train.txt', 'w') as f:
-        for item in train:
-            f.write("%s\n" % item)
-
-    # save test part
-    with open(f'{target_upfolder}/test.txt', 'w') as f:
-        for item in test:
-            f.write("%s\n" % item)
+        self.tiler(imnames, self.target, self.falsefolder, self.size, self.ext)
+        self.splitter(self.target, target_upfolder, self.ext, self.ratio)
 
 if __name__ == "__main__":
-    # Initialize parser
     parser = argparse.ArgumentParser()
 
     parser.add_argument("-source", default="./yolosample/ts/", help = "Source folder with images and labels needed to be tiled")
@@ -138,33 +161,5 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    imnames = glob.glob(f'{args.source}/*{args.ext}')
-    labnames = glob.glob(f'{args.source}/*.txt')
-    
-    if len(imnames) == 0:
-        raise Exception("Source folder should contain some images")
-    elif len(imnames) != len(labnames):
-        raise Exception("Dataset should contain equal number of images and txt files with labels")
-
-    if not os.path.exists(args.target):
-        os.makedirs(args.target)
-    elif len(os.listdir(args.target)) > 0:
-        raise Exception("Target folder should be empty")
-
-    # classes.names should be located one level higher than images   
-    # this file is not changing, so we will just copy it to a target folder 
-    upfolder = os.path.join(args.source, '..' )
-    target_upfolder = os.path.join(args.target, '..' )
-    if not os.path.exists(os.path.join(upfolder, 'classes.names')):
-        print('classes.names not found. It should be located one level higher than images')
-    else:
-        copyfile(os.path.join(upfolder, 'classes.names'), os.path.join(target_upfolder, 'classes.names'))
-    
-    if args.falsefolder:
-        if not os.path.exists(args.falsefolder):
-            os.makedirs(args.falsefolder)
-        elif len(os.listdir(args.falsefolder)) > 0:
-            raise Exception("Folder for tiles without boxes should be empty")
-
-    tiler(imnames, args.target, args.falsefolder, args.size, args.ext)
-    splitter(args.target, target_upfolder, args.ext, args.ratio)
+    yolo_tiler = YoloTiler(args.source, args.target, args.ext, args.falsefolder, args.size, args.ratio)
+    yolo_tiler.run()


### PR DESCRIPTION
Refactor `tile_yolo.py` to encapsulate functionality within a `YoloTiler` class.

* Create `YoloTiler` class with `__init__`, `tiler`, `splitter`, and `run` methods.
* Move `tiler` function into `YoloTiler` class as a method.
* Move `splitter` function into `YoloTiler` class as a method.
* Move argument parsing and main execution logic into `YoloTiler` class's `__init__` and `run` methods.
* Update `if __name__ == "__main__":` block to create an instance of `YoloTiler` and call its `run` method.

Update `README.md` to reflect the new class-based usage of the script.

* Add a section for class-based usage with an example of creating an instance of `YoloTiler` and calling its `run` method.
