### PR TITLE
Ensure source and target folders are YOLO formatted

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,7 @@ from yolo_tiling import YoloTiler
 yolo_tiler = YoloTiler(source="./yolosample/ts/", target="./yolosliced/ts/", ext=".JPG", falsefolder=None, size=512, ratio=0.8, annotation_type="instance_segmentation")
 yolo_tiler.run()
 ```
+
+## Note
+
+The source and target folders must be YOLO formatted with `train`, `val`, `test` subfolders, each containing `images/` and `labels/` subfolders.

--- a/yolo_tiling/__init__.py
+++ b/yolo_tiling/__init__.py
@@ -24,6 +24,17 @@ class YoloTiler:
         self.ratio = ratio
         self.annotation_type = annotation_type
 
+    def check_yolo_format(self, folder):
+        required_subfolders = ['train', 'val', 'test']
+        for subfolder in required_subfolders:
+            subfolder_path = os.path.join(folder, subfolder)
+            if not os.path.exists(subfolder_path):
+                raise Exception(f"Folder {subfolder_path} does not exist")
+            if not os.path.exists(os.path.join(subfolder_path, 'images')):
+                raise Exception(f"Folder {os.path.join(subfolder_path, 'images')} does not exist")
+            if not os.path.exists(os.path.join(subfolder_path, 'labels')):
+                raise Exception(f"Folder {os.path.join(subfolder_path, 'labels')} does not exist")
+
     def tiler(self, imnames, newpath, falsepath, slice_size, ext):
         for imname in imnames:
             im = Image.open(imname)
@@ -158,6 +169,9 @@ class YoloTiler:
                 f.write("%s\n" % item)
 
     def run(self):
+        self.check_yolo_format(self.source)
+        self.check_yolo_format(self.target)
+
         imnames = glob.glob(f'{self.source}/*{self.ext}')
         labnames = glob.glob(f'{self.source}/*.txt')
 


### PR DESCRIPTION
Add checks for YOLO formatted folders in `YoloTiler` class and update `README.md`.

* **README.md**
  - Add a note specifying that the source and target folders must be YOLO formatted with `train`, `val`, `test` subfolders, each containing `images/` and `labels/` subfolders.

* **yolo_tiling/__init__.py**
  - Add `check_yolo_format` method to `YoloTiler` class to check if the source and target folders contain `train`, `val`, `test` subfolders, each with `images/` and `labels/` subfolders.
  - Call `check_yolo_format` method in the `run` method of `YoloTiler` class to ensure the source and target folders follow the required YOLO format.
