### PR TITLE
Add data split functionality to YoloTiler

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -19,3 +19,43 @@ tiler = YoloTiler(
 )
 
 tiler.run()
+
+def test_split_data():
+    src = "C:/Users/jordan.pierce/Downloads/TagLab/sampleProjects/data/segmentation"
+    dst = "C:/Users/jordan.pierce/Downloads/TagLab/sampleProjects/data/segmentation_tiled_split"
+
+    config = TileConfig(
+        slice_wh=(640, 480),  # Slice width and height
+        overlap_wh=(64, 48),  # Overlap width and height (10% overlap in this example)
+        ratio=0.8,  # Train/test split ratio
+        ext=".png",
+        annotation_type="instance_segmentation",
+        train_ratio=0.7,
+        valid_ratio=0.2,
+        test_ratio=0.1
+    )
+
+    tiler = YoloTiler(
+        source=src,
+        target=dst,
+        config=config,
+    )
+
+    tiler.split_data()
+
+    # Check if the split data exists in the target directory
+    assert os.path.exists(os.path.join(dst, 'train', 'images'))
+    assert os.path.exists(os.path.join(dst, 'valid', 'images'))
+    assert os.path.exists(os.path.join(dst, 'test', 'images'))
+
+    train_images = os.listdir(os.path.join(dst, 'train', 'images'))
+    valid_images = os.listdir(os.path.join(dst, 'valid', 'images'))
+    test_images = os.listdir(os.path.join(dst, 'test', 'images'))
+
+    # Check if the split ratios are approximately correct
+    total_images = len(train_images) + len(valid_images) + len(test_images)
+    assert abs(len(train_images) / total_images - 0.7) < 0.1
+    assert abs(len(valid_images) / total_images - 0.2) < 0.1
+    assert abs(len(test_images) / total_images - 0.1) < 0.1
+
+test_split_data()


### PR DESCRIPTION
Add functionality to split train data into train, valid, and test sets using specified ratios.

* Add `train_ratio`, `valid_ratio`, and `test_ratio` attributes to `TileConfig` class in `src/yolo_tiler.py`.
* Add `split_data` method to `YoloTiler` class in `src/yolo_tiler.py` to handle splitting train data into train, valid, and test sets using specified ratios.
* Modify `run` method in `YoloTiler` class to call `split_data` method if valid or test folders are empty.
* Add `_save_split_data` helper method to `YoloTiler` class to save split data to the appropriate folder.
* Add test cases in `tests/test.py` to verify the functionality of `split_data` method in `YoloTiler` class.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Jordan-Pierce/yolo-tiling/pull/8?shareId=1927c6a2-2777-4c03-9d78-76295977fa1c).