### PR TITLE
Add command line interface using argparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,31 @@ tiler = YoloTiler(
 tiler.run()
 ```
 
+## Command Line Usage
+
+You can also use the command line interface to run the tiling process. Here are the instructions:
+
+```bash
+python src/yolo_tiler.py <source> <target> [--slice_wh SLICE_WH SLICE_WH] [--overlap_wh OVERLAP_WH OVERLAP_WH] [--ext EXT] [--annotation_type ANNOTATION_TYPE] [--densify_factor DENSIFY_FACTOR] [--smoothing_tolerance SMOOTHING_TOLERANCE] [--train_ratio TRAIN_RATIO] [--valid_ratio VALID_RATIO] [--test_ratio TEST_RATIO]
+```
+
+### Example Commands
+
+1. Basic usage with default parameters:
+```bash
+python src/yolo_tiler.py path/to/dataset path/to/tiled_dataset
+```
+
+2. Custom slice size and overlap:
+```bash
+python src/yolo_tiler.py path/to/dataset path/to/tiled_dataset --slice_wh 640 480 --overlap_wh 64 48
+```
+
+3. Custom annotation type and image extension:
+```bash
+python src/yolo_tiler.py path/to/dataset path/to/tiled_dataset --annotation_type instance_segmentation --ext .jpg
+```
+
 ## Note
 
 The source and target folders must be YOLO formatted with `train`, `val`, `test` subfolders, each containing 

--- a/src/yolo_tiler.py
+++ b/src/yolo_tiler.py
@@ -11,6 +11,7 @@ from PIL import Image
 from shapely.geometry import Polygon, MultiPolygon
 from tqdm import tqdm
 import random
+import argparse
 
 
 @dataclass
@@ -510,3 +511,46 @@ class YoloTiler:
         except Exception as e:
             self.logger.error(f'Error during tiling process: {str(e)}')
             raise
+
+
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Tile YOLO dataset images and annotations.")
+    parser.add_argument("source", type=str, help="Source directory containing YOLO dataset")
+    parser.add_argument("target", type=str, help="Target directory for sliced dataset")
+    parser.add_argument("--slice_wh", type=int, nargs=2, default=(640, 480), help="Slice width and height")
+    parser.add_argument("--overlap_wh", type=int, nargs=2, default=(64, 48), help="Overlap width and height")
+    parser.add_argument("--ext", type=str, default=".png", help="Image extension")
+    parser.add_argument("--annotation_type", type=str, default="object_detection", help="Type of annotation")
+    parser.add_argument("--densify_factor", type=float, default=0.01, help="Densify factor for segmentation")
+    parser.add_argument("--smoothing_tolerance", type=float, default=0.99, help="Smoothing tolerance for segmentation")
+    parser.add_argument("--train_ratio", type=float, default=0.7, help="Train split ratio")
+    parser.add_argument("--valid_ratio", type=float, default=0.2, help="Validation split ratio")
+    parser.add_argument("--test_ratio", type=float, default=0.1, help="Test split ratio")
+    return parser.parse_args()
+
+
+def main():
+    """Main function to run the tiling process based on command line arguments."""
+    args = parse_args()
+    config = TileConfig(
+        slice_wh=tuple(args.slice_wh),
+        overlap_wh=tuple(args.overlap_wh),
+        ext=args.ext,
+        annotation_type=args.annotation_type,
+        densify_factor=args.densify_factor,
+        smoothing_tolerance=args.smoothing_tolerance,
+        train_ratio=args.train_ratio,
+        valid_ratio=args.valid_ratio,
+        test_ratio=args.test_ratio
+    )
+    tiler = YoloTiler(
+        source=args.source,
+        target=args.target,
+        config=config,
+    )
+    tiler.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add a command line interface using `argparse` to `src/yolo_tiler.py` and update `README.md` with instructions.

* **Command Line Interface:**
  - Import `argparse` module.
  - Add `parse_args` function to handle command line arguments.
  - Add `main` function to run the tiling process based on command line arguments.
  - Add a check to call `main` if the script is run directly.

* **README.md:**
  - Add a new section "## Command Line Usage" with instructions on how to use the command line interface.
  - Provide example commands for running the tiling process from the command line.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Jordan-Pierce/yolo-tiling/pull/10?shareId=49abb213-28b5-4e21-9db3-c599e5fe2476).