### PR TITLE
Modify overlap ratio to accept ratio or integer

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ dst = "path/to/tiled_dataset"
 
 config = TileConfig(
     slice_wh=(640, 480),  # Slice width and height
-    overlap_wh=(64, 48),  # Overlap width and height (10% overlap in this example)
+    overlap_wh=(0.1, 0.1),  # Overlap width and height (10% overlap in this example)
     ext=".png",
     annotation_type="instance_segmentation",
     train_ratio=0.7,
@@ -58,7 +58,7 @@ python src/yolo_tiler.py path/to/dataset path/to/tiled_dataset
 
 2. Custom slice size and overlap:
 ```bash
-python src/yolo_tiler.py path/to/dataset path/to/tiled_dataset --slice_wh 640 480 --overlap_wh 64 48
+python src/yolo_tiler.py path/to/dataset path/to/tiled_dataset --slice_wh 640 480 --overlap_wh 0.1 0.1
 ```
 
 3. Custom annotation type and image extension:

--- a/tests/test.py
+++ b/tests/test.py
@@ -5,7 +5,7 @@ dst = "C:/Users/jordan.pierce/Downloads/TagLab/sampleProjects/data/segmentation_
 
 config = TileConfig(
     slice_wh=(640, 480),  # Slice width and height
-    overlap_wh=(64, 48),  # Overlap width and height (10% overlap in this example)
+    overlap_wh=(0.1, 0.1),  # Overlap width and height (10% overlap in this example)
     ext=".png",
     annotation_type="instance_segmentation",
     train_ratio=0.7,


### PR DESCRIPTION
Modify the `overlap_wh` parameter to accept a ratio between 0-1 or an integer.

* **README.md**
  - Update the `overlap_wh` parameter description and example usage to show ratio values.

* **src/yolo_tiler.py**
  - Modify the `overlap_wh` parameter in the `TileConfig` class to accept a tuple of floats or integers.
  - Update the `__post_init__` method to validate the overlap values as either non-negative integers or floats between 0 and 1.
  - Update the `_calculate_step_size` method to handle both integer and ratio values for the overlap.
  - Update the argparse argument for `overlap_wh` to accept float values.

* **tests/test.py**
  - Update the `overlap_wh` parameter in the test configuration to show ratio values.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Jordan-Pierce/yolo-tiling/pull/11?shareId=59a89640-6452-4739-9ea0-5068ca93b2ab).