### PR TITLE
Update tile_image method to use margins

### DIFF
--- a/src/yolo_tiler.py
+++ b/src/yolo_tiler.py
@@ -314,6 +314,11 @@ class YoloTiler:
         image_array = np.array(image, dtype=np.uint8)
         width, height = image.size
 
+        # Get effective area
+        x_min, y_min, x_max, y_max = self.config.get_effective_area(width, height)
+        effective_width = x_max - x_min
+        effective_height = y_max - y_min
+
         # Process annotations
         boxes = []
         with open(label_path) as f:
@@ -343,9 +348,9 @@ class YoloTiler:
                     boxes.append((class_id, Polygon(points)))
 
         # Process each tile
-        for tile_idx, (x1, y1, x2, y2) in tqdm(enumerate(self._calculate_tile_positions((width, height)))):
-            tile_data = image_array[y1:y2, x1:x2]
-            tile_polygon = Polygon([(x1, y1), (x2, y1), (x2, y2), (x1, y2)])
+        for tile_idx, (x1, y1, x2, y2) in tqdm(enumerate(self._calculate_tile_positions((effective_width, effective_height)))):
+            tile_data = image_array[y1 + y_min:y2 + y_min, x1 + x_min:x2 + x_min]
+            tile_polygon = Polygon([(x1 + x_min, y1 + y_min), (x2 + x_min, y1 + y_min), (x2 + x_min, y2 + y_min), (x1 + x_min, y2 + y_min)])
             tile_labels = []
 
             # Process annotations for this tile


### PR DESCRIPTION
Update the `tile_image` method in `src/yolo_tiler.py` to take advantage of margins and calculate an effective area for tiling.

* Add a call to `get_effective_area` in the `tile_image` method to calculate the effective area to be tiled.
* Update the `_calculate_tile_positions` method to use the effective area instead of the full image size.
* Update the `tile_image` method to use the effective area for tiling.
* Adjust the tile data and tile polygon calculations to account for the effective area.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Jordan-Pierce/yolo-tiling/pull/12?shareId=3853f2f7-0c65-4fc7-97fb-0678b2ec9a6e).