### PR TITLE
Add include_negative_samples parameter to YoloTiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,10 @@ config = TileConfig(
     # - Tuple of floats for different margins: margins=(0.1, 0.1, 0.1, 0.1)
     # - Single integer for pixel margins: margins=64
     # - Tuple of integers for different pixel margins: margins=(64, 64, 64, 64)
-    margins=0.0
+    margins=0.0,
+
+    # Include negative samples (tiles without any instances)
+    include_negative_samples=True
 )
 
 tiler = YoloTiler(

--- a/tests/test_yolo_tiler.py
+++ b/tests/test_yolo_tiler.py
@@ -22,6 +22,7 @@ config = TileConfig(
     valid_ratio=0.2,
     test_ratio=0.1,
     margins=(0, 0, 0, 0),  # Left, top, right, bottom
+    include_negative_samples=True  # Inlude negative samples
 )
 
 

--- a/yolo_tiler/yolo_tiler.py
+++ b/yolo_tiler/yolo_tiler.py
@@ -37,11 +37,13 @@ class TileConfig:
                  train_ratio: float = 0.8,
                  valid_ratio: float = 0.1,
                  test_ratio: float = 0.1,
-                 margins: Union[float, Tuple[float, float, float, float]] = 0.0):
+                 margins: Union[float, Tuple[float, float, float, float]] = 0.0,
+                 include_negative_samples: bool = True):
         """
         Args:
             margins: Either a single float (0-1) for uniform margins,
                     or tuple (left, top, right, bottom) of floats (0-1) or ints
+            include_negative_samples: Boolean to determine if negative samples should be included
         """
         self.slice_wh = slice_wh if isinstance(slice_wh, tuple) else (slice_wh, slice_wh)
         self.overlap_wh = overlap_wh
@@ -52,6 +54,7 @@ class TileConfig:
         self.train_ratio = train_ratio
         self.valid_ratio = valid_ratio
         self.test_ratio = test_ratio
+        self.include_negative_samples = include_negative_samples
 
         # Handle margins
         if isinstance(margins, (int, float)):
@@ -479,9 +482,10 @@ class YoloTiler:
                             normalized = self._normalize_coordinates(coord_lists, (abs_x1, abs_y1, abs_x2, abs_y2))
                             tile_labels.append([box_class, normalized])
 
-                # Save tile image and labels
-                tile_suffix = f'_tile_{tile_idx}{self.config.ext}'
-                self._save_tile(tile_data, image_path, tile_suffix, tile_labels, folder)
+                # Save tile image and labels if include_negative_samples is True or there are labels
+                if self.config.include_negative_samples or tile_labels:
+                    tile_suffix = f'_tile_{tile_idx}{self.config.ext}'
+                    self._save_tile(tile_data, image_path, tile_suffix, tile_labels, folder)
 
     def _save_tile_image(self, tile_data: np.ndarray, image_path: Path, suffix: str, folder: str) -> None:
         """


### PR DESCRIPTION
Add `include_negative_samples` parameter to `YoloTiler` to determine if a tiled image and corresponding label file should be saved based on the label file having at least one instance.

* Modify `TileConfig` class constructor and initialization to include `include_negative_samples` parameter in `yolo_tiler/yolo_tiler.py`
* Update `tile_image` method to check for `include_negative_samples` before saving tiled image and labels in `yolo_tiler/yolo_tiler.py`
* Add test case to verify `include_negative_samples` parameter functionality in `tests/test_yolo_tiler.py`
* Update usage example to include `include_negative_samples` parameter in `TileConfig` in `README.md`

