### PR TITLE
Bump version: 0.0.19 → 0.0.20

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yolo-tiling"
-version = "0.0.19"
+version = "0.0.20"
 dynamic = [
     "dependencies",
 ]
@@ -42,7 +42,7 @@ universal = true
 
 
 [tool.bumpversion]
-current_version = "0.0.19"
+current_version = "0.0.20"
 commit = true
 tag = true
 

--- a/yolo_tiler/__init__.py
+++ b/yolo_tiler/__init__.py
@@ -2,7 +2,7 @@
 
 from yolo_tiler.yolo_tiler import YoloTiler, TileConfig, TileProgress
 
-__version__ = "0.0.19"
+__version__ = "0.0.20"
 __author__ = "Jordan Pierce"
 __email__ = "jordan.pierce@noaa.gov"
 __credits__ = "National Center for Coastal and Ocean Sciences (NCCOS)"


### PR DESCRIPTION
This pull request updates the project version from 0.0.19 to 0.0.20 across all relevant files. No other functional or code changes are included.

- Version bump:
  * Updated the version in `pyproject.toml`, `[tool.bumpversion]` section, and `yolo_tiler/__init__.py` to 0.0.20. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L45-R45) [[3]](diffhunk://#diff-cc015a80e42e8e70634605a7666c3ced0a9f550abdf81d30fdd8ef26bfce179fL5-R5)