### PR TITLE
Semantic (Updated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ config = TileConfig(
     input_ext=".png",
 
     # Output image file extension to save (default: same as input_ext)
-    # Note: Must be .png for semantic_segmentation
+    # Note: Output mask must be .png for semantic_segmentation
     output_ext=None,
 
     # Type of YOLO annotations to process:
@@ -175,7 +175,7 @@ dataset/
     └── class_2/
 ```
 
-**Note**: For semantic segmentation, the `labels/` folders contain PNG mask files (single channel, uint8) where pixel values represent class IDs (0 = background, 1-255 = classes). For object detection and instance segmentation, the `labels/` folders contain `.txt` files with YOLO format annotations.
+**Note**: For semantic segmentation, the `labels/` folders contain PNG mask files (single channel, uint8) where pixel values represent class IDs (0 = background, 1-255 = classes). Tiled masks are also saved as PNG files regardless of the output format specified for images. For object detection and instance segmentation, the `labels/` folders contain `.txt` files with YOLO format annotations.
 
 ### Test Data
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yolo-tiling"
-version = "0.0.21"
+version = "0.0.22"
 dynamic = [
     "dependencies",
 ]
@@ -42,7 +42,7 @@ universal = true
 
 
 [tool.bumpversion]
-current_version = "0.0.21"
+current_version = "0.0.22"
 commit = true
 tag = true
 

--- a/yolo_tiler/__init__.py
+++ b/yolo_tiler/__init__.py
@@ -2,7 +2,7 @@
 
 from yolo_tiler.yolo_tiler import YoloTiler, TileConfig, TileProgress
 
-__version__ = "0.0.21"
+__version__ = "0.0.22"
 __author__ = "Jordan Pierce"
 __email__ = "jordan.pierce@noaa.gov"
 __credits__ = "National Center for Coastal and Ocean Sciences (NCCOS)"


### PR DESCRIPTION
This pull request updates the package to version 0.0.22 and improves the handling and documentation of output formats for semantic segmentation masks. The main changes clarify and enforce that semantic segmentation masks are always saved as PNG files, regardless of the specified output format for images, and update related documentation accordingly.

**Semantic segmentation mask handling:**

* Updated the logic in `_save_tile_labels` in `yolo_tiler/yolo_tiler.py` to always save semantic segmentation masks as PNG files, constructing the output filename to ensure the `.png` extension is used regardless of the configured output format.
* Removed an overly strict output format validation in the `TileConfig` initialization that previously raised an error if `output_ext` was not `.png` for semantic segmentation, since the code now always saves masks as PNGs internally.

**Documentation updates:**

* Clarified in `README.md` that for semantic segmentation, tiled masks are always saved as PNG files regardless of the image output format.
* Updated a comment in the configuration example in `README.md` to specify that the output mask must be `.png` for semantic segmentation.

**Version bump:**

* Bumped the version number to 0.0.22 in `pyproject.toml`, `yolo_tiler/__init__.py`, and the bumpversion config. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L45-R45) [[3]](diffhunk://#diff-cc015a80e42e8e70634605a7666c3ced0a9f550abdf81d30fdd8ef26bfce179fL5-R5)