### PR TITLE
Bug Fix: Exclude negative samples for semantic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ ENV/
 tests/detection_tiled
 tests/segmentation_tiled
 tests/classification_tiled
+
+*.pt
+*.pth

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yolo-tiling"
-version = "0.0.25"
+version = "0.0.26"
 dynamic = [
     "dependencies",
 ]
@@ -42,7 +42,7 @@ universal = true
 
 
 [tool.bumpversion]
-current_version = "0.0.25"
+current_version = "0.0.26"
 commit = true
 tag = true
 

--- a/yolo_tiler/__init__.py
+++ b/yolo_tiler/__init__.py
@@ -2,7 +2,7 @@
 
 from yolo_tiler.yolo_tiler import YoloTiler, TileConfig, TileProgress
 
-__version__ = "0.0.25"
+__version__ = "0.0.26"
 __author__ = "Jordan Pierce"
 __email__ = "jordan.pierce@noaa.gov"
 __credits__ = "National Center for Coastal and Ocean Sciences (NCCOS)"

--- a/yolo_tiler/yolo_tiler.py
+++ b/yolo_tiler/yolo_tiler.py
@@ -711,12 +711,31 @@ class YoloTiler:
                                 tile_labels.append([box_class, normalized])
 
                 # Save tile image and labels if include_negative_samples is True or there are labels
-                if self.config.include_negative_samples or tile_labels:
+                if self.config.include_negative_samples or self._has_annotations(tile_labels):
                     # Calculate width and height for the new naming convention
                     tile_width = abs_x2 - abs_x1
                     tile_height = abs_y2 - abs_y1
                     tile_coords = (abs_x1, abs_y1, tile_width, tile_height)
                     self._save_tile(tile_data, image_path, tile_coords, tile_labels, folder)
+                    
+    def _has_annotations(self, tile_labels) -> bool:
+        """
+        Check if tile has annotations based on annotation type.
+
+        Args:
+            tile_labels: Labels data (list for detection/segmentation, numpy array for semantic segmentation)
+
+        Returns:
+            bool: True if tile has annotations, False otherwise
+        """
+        if self.annotation_type == "semantic_segmentation":
+            # For semantic segmentation, tile_labels is a numpy array (mask)
+            # Check if mask contains any non-zero values (background is typically 0)
+            return isinstance(tile_labels, np.ndarray) and np.any(tile_labels > 0)
+        else:
+            # For other annotation types, tile_labels is a list
+            # Check if list is not empty
+            return bool(tile_labels)
 
     def _save_tile_image(self, tile_data: np.ndarray, image_path: Path, suffix: str, folder: str) -> None:
         """


### PR DESCRIPTION
This pull request improves how tile annotations are checked before saving tile images and labels, making the logic more robust and adaptable to different annotation types. The main change is the introduction of a new helper method to determine if a tile contains relevant annotations, ensuring semantic segmentation masks are handled correctly.

Annotation handling improvements:

* Added a new `_has_annotations` method to check for the presence of annotations, supporting both list-based (detection/segmentation) and numpy array-based (semantic segmentation) label formats.
* Updated the condition for saving tile images and labels to use `_has_annotations`, ensuring semantic segmentation tiles are only saved if they contain non-background pixels.