### PR TITLE
Semantic segmentation, ignoring Alpha channels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yolo-tiling"
-version = "0.0.27"
+version = "0.0.28"
 dynamic = [
     "dependencies",
 ]
@@ -42,7 +42,7 @@ universal = true
 
 
 [tool.bumpversion]
-current_version = "0.0.27"
+current_version = "0.0.28"
 commit = true
 tag = true
 

--- a/tests/test_alpha_channel.py
+++ b/tests/test_alpha_channel.py
@@ -1,0 +1,49 @@
+import numpy as np
+import rasterio
+from PIL import Image
+
+from yolo_tiler import TileConfig, YoloTiler
+
+
+def test_rgba_tiles_are_saved_without_alpha_channel(tmp_path):
+    source_dir = tmp_path / "source"
+    target_dir = tmp_path / "target"
+    image_dir = source_dir / "train" / "images"
+    label_dir = source_dir / "train" / "labels"
+    image_dir.mkdir(parents=True)
+    label_dir.mkdir(parents=True)
+
+    image_path = image_dir / "rgba.png"
+    rgba = np.zeros((8, 8, 4), dtype=np.uint8)
+    rgba[..., 0] = 40
+    rgba[..., 1] = 80
+    rgba[..., 2] = 120
+    rgba[..., 3] = 200
+    Image.fromarray(rgba, mode="RGBA").save(image_path)
+
+    (label_dir / "rgba.txt").write_text("0 0.5 0.5 1 1\n", encoding="utf-8")
+
+    tiler = YoloTiler(
+        source=source_dir,
+        target=target_dir,
+        config=TileConfig(
+            slice_wh=(8, 8),
+            overlap_wh=(0, 0),
+            annotation_type="object_detection",
+            output_ext=".png",
+            include_negative_samples=True,
+        ),
+        num_viz_samples=0,
+        show_processing_status=False,
+    )
+
+    try:
+        tiler._process_subfolder("train/")
+
+        output_files = list((target_dir / "train" / "images").glob("*.png"))
+        assert len(output_files) == 1
+
+        with rasterio.open(output_files[0]) as src:
+            assert src.count == 3
+    finally:
+        tiler.save_executor.shutdown(wait=True)

--- a/yolo_tiler/__init__.py
+++ b/yolo_tiler/__init__.py
@@ -2,7 +2,7 @@
 
 from yolo_tiler.yolo_tiler import YoloTiler, TileConfig, TileProgress
 
-__version__ = "0.0.27"
+__version__ = "0.0.28"
 __author__ = "Jordan Pierce"
 __email__ = "jordan.pierce@noaa.gov"
 __credits__ = "National Center for Coastal and Ocean Sciences (NCCOS)"

--- a/yolo_tiler/yolo_tiler.py
+++ b/yolo_tiler/yolo_tiler.py
@@ -55,6 +55,30 @@ def _save_labels_worker(labels: List, path: Path, is_segmentation: bool) -> None
         df.to_csv(path, sep=' ', index=False, header=False, float_format='%.6f')
 
 
+def _drop_alpha_bands(tile_data: np.ndarray, color_interpretations) -> np.ndarray:
+    """Remove alpha bands from a raster tile when present."""
+    if tile_data.ndim != 3:
+        return tile_data
+
+    alpha_band_indices = [
+        idx for idx, color_interp in enumerate(color_interpretations)
+        if getattr(color_interp, 'name', '').lower() == 'alpha'
+    ]
+
+    if not alpha_band_indices:
+        return tile_data
+
+    keep_band_indices = [
+        idx for idx in range(tile_data.shape[0])
+        if idx not in alpha_band_indices
+    ]
+
+    if len(keep_band_indices) == tile_data.shape[0]:
+        return tile_data
+
+    return tile_data[keep_band_indices, :, :]
+
+
 def _save_tile_image_worker(tile_data: np.ndarray, 
                             image_path_out: Path, 
                             compression_quality: int) -> None:
@@ -1080,6 +1104,7 @@ class YoloTiler:
 
                         # Read image data *after* the potential skip
                         tile_data = src.read(window=window)
+                        tile_data = _drop_alpha_bands(tile_data, src.colorinterp)
 
                         # Create polygon for current tile
                         tile_polygon = Polygon([
@@ -1547,6 +1572,7 @@ class YoloTiler:
                 # For detection and segmentation tasks
                 source_img_dir = self.source / subfolder / "images"
                 source_lbl_dir = self._get_source_label_folder(subfolder)
+                label_pattern = "*.png" if self.annotation_type == "semantic_segmentation" else "*.txt"
                 
                 if source_img_dir.exists() and source_lbl_dir.exists():
                     label_folder = self._get_label_folder_name()


### PR DESCRIPTION
This pull request introduces support for handling images with alpha channels (transparency) in the tiling workflow. The main focus is to ensure that any RGBA (4-band) images are saved as standard RGB (3-band) images, with the alpha channel removed during processing. This prevents issues with downstream tools that may not support alpha channels. Additionally, a new test is added to verify this behavior.

**Alpha Channel Handling:**

* Added a `_drop_alpha_bands` function to remove alpha bands from raster image data arrays before saving tiles, ensuring output images only contain RGB channels.
* Integrated the `_drop_alpha_bands` function into the image tiling pipeline so that alpha channels are dropped automatically during tile extraction.

**Testing:**

* Added a new test, `test_rgba_tiles_are_saved_without_alpha_channel`, which generates a synthetic RGBA image, runs the tiler, and asserts that the output tile only has three bands (no alpha channel).

**Minor Improvements:**

* Adjusted label file pattern selection logic to choose between `*.png` and `*.txt` based on annotation type, improving source data copying robustness.